### PR TITLE
ROS2 foxy support on Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,9 @@ include(GoogleTest)
 
 project(bottlenose_camera_driver)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 17)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 This driver currently supports color-image streaming from Bottlenose Mono and Stereo.
 
 ## Requirements 
-  * ROS2 Foxy or newer, tested with [ROS2 Humble](https://docs.ros.org/en/foxy/Releases/Release-Humble-Hawksbill.html) on Ubuntu 22.04
+  * ROS2 Foxy or newer:
+    * tested with [ROS2 Humble](https://docs.ros.org/en/foxy/Releases/Release-Humble-Hawksbill.html) on Ubuntu 22.04
+    * tested with [ROS2 Foxy](https://docs.ros.org/en/foxy/Releases/Release-Foxy-Fitzroy.html) on Ubuntu 20.04
   * eBUS SDK 6.3, please see the releases in our [SDK Demos](https://github.com/labforge/sdk-demos/releases)
   * Bottlenose Mono or Stereo Camera, at [firmware](https://github.com/labforge/bottlenose/releases/) v0.1.100 or newer
 

--- a/include/bottlenose_camera_driver.hpp
+++ b/include/bottlenose_camera_driver.hpp
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 #include <iostream>
+#include <variant>
 #include "rclcpp/rclcpp.hpp"
 
 #include "std_msgs/msg/string.hpp"

--- a/src/bottlenose_camera_driver.cpp
+++ b/src/bottlenose_camera_driver.cpp
@@ -18,6 +18,7 @@
 @author Thomas Reidemeister <thomas@labforge.ca>
 */
 
+#include <unistd.h>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -330,7 +331,8 @@ bool CameraDriver::connect() {
   }
   PvDevice *device = PvDevice::CreateAndConnect( pDevice->GetConnectionID(), &res );
   if(res.IsFailure() || device == nullptr) {
-    RCLCPP_ERROR(get_logger(), "Could not connect to device %s", m_mac_address.c_str());
+    RCLCPP_ERROR(get_logger(), "Could not connect to device %s\nCause: %s\nDescription: %s",
+                 m_mac_address.c_str(), res.GetCodeString().GetAscii(), res.GetDescription().GetAscii());
     return false;
   }
   PvGenInteger *intval = dynamic_cast<PvGenInteger *>( device->GetParameters()->Get("GevSCPSPacketSize"));
@@ -385,7 +387,7 @@ bool CameraDriver::connect() {
                            "MaximumResendGroupSize",
                            "ResendRequestTimeout",
                            "RequestTimeout"}) {
-    intval = static_cast<PvGenInteger *>( stream->GetParameters()->Get("ResendRequestTimeout"));
+    intval = static_cast<PvGenInteger *>( stream->GetParameters()->Get(param));
     res = intval->SetValue(get_parameter(param).as_int());
     if (res.IsFailure()) {
       RCLCPP_ERROR(get_logger(), "Could not adjust communication parameters");


### PR DESCRIPTION
 * CMake adjustments for ROS2 foxy on Ubuntu 20.04
 * More verbose error logging for connection problems
 * G++-11 adjustments for Ubuntu 20.04