### PR TITLE
Bugfix for SE-2565, support for NTP (SE-2568)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,8 @@ jobs:
 
       - name: Power off CI
         uses: ./.github/workflows/ci/power
+        if: always()
         with:
-          if: always()
           state: 'off'
 
       - name: Unlock HIL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(camera_calibration_parsers REQUIRED)
 find_package(OpenCV 4 REQUIRED)
 
 add_library(bottlenose_camera_driver SHARED
-        src/bottlenose_camera_driver.cpp)
+        src/bottlenose_camera_driver.cpp
+        src/bottlenose_chunk_parser.cpp)
 target_compile_definitions(bottlenose_camera_driver
   PRIVATE "COMPOSITION_BUILDING_DLL")
 target_include_directories(bottlenose_camera_driver

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ros2 run bottlenose_camera_driver bottlenose_camera_driver_node --ros-args -p ma
 | ```keep_partial```                       | Keep partial images (i.e. corrupted in transmission)                          | ```false```                      | :white_check_mark:  |
 | ```format```                             | Format of the camera (*)                                                      | ```1920x1080```                  |                     |
 | ```fps```                                | Target frames per second (*)                                                  | ```10.0```                       |                     |
+| ```ntpEnable```                          | Enable NTP UDP broadcast receptions on Bottlenose                             | ```false```                      |                     |
 | ***Image Sensor(s) Controls***           | (**)                                                                          |                                  |                     |
 | ```exposure```                           | Exposure time in milliseconds                                                 | ```20.0```                       | :white_check_mark:  |
 | ```gain```                               | Analog gain                                                                   | ```1.0```                        | :white_check_mark:  |

--- a/include/bottlenose_camera_driver.hpp
+++ b/include/bottlenose_camera_driver.hpp
@@ -72,12 +72,15 @@ namespace bottlenose_camera_driver {
     void management_thread();             ///< Management thread for interacting with GEV stack.
     void status_callback();               ///< ROS2 status callback and orchestration polled from a timer.
     bool is_ebus_loaded();                ///< Check if the eBusSDK Driver is loaded.
+    bool enable_chunk(std::string chunk); ///< Enable chunk data
+    bool enable_ntp(bool enable);         ///< Enable NTP
 
     bool load_calibration(uint32_t sid, std::string cname); ///< load calibration data
     bool set_calibration();                 ///< set calibration on to camera
     uint32_t get_num_sensors();             ///< returns the number of sensors: 1=mono and 2=stereo    
     bool set_register(std::string, std::variant<int64_t, double, bool>); ///< set a register value on the camera
     bool m_calibrated;
+    bool m_ntp_enabled;
     
     std::atomic<bool> done;               ///< Flag for management thread to terminate.
     std::thread m_thread;                 ///< Management thread handle.

--- a/include/bottlenose_camera_driver.hpp
+++ b/include/bottlenose_camera_driver.hpp
@@ -21,7 +21,7 @@
 #ifndef __BOTTLENOSE_CAMERA_DRIVER_HPP__
 #define __BOTTLENOSE_CAMERA_DRIVER_HPP__
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <variant>
 #include "rclcpp/rclcpp.hpp"
@@ -50,7 +50,7 @@ namespace bottlenose_camera_driver {
     explicit CameraDriver(const rclcpp::NodeOptions&);
     bool is_streaming();
     bool isCalibrated();
-    ~CameraDriver();
+    ~CameraDriver() override;
   private:
     /**
      * Convert the frame to a ROS2 message.
@@ -71,7 +71,7 @@ namespace bottlenose_camera_driver {
     void abort_buffers();                 ///< Abort buffers for GEV stack.
     void management_thread();             ///< Management thread for interacting with GEV stack.
     void status_callback();               ///< ROS2 status callback and orchestration polled from a timer.
-    bool is_ebus_loaded();                ///< Check if the eBusSDK Driver is loaded.
+    static bool is_ebus_loaded();         ///< Check if the eBusSDK Driver is loaded.
     bool enable_chunk(std::string chunk); ///< Enable chunk data
     bool enable_ntp(bool enable);         ///< Enable NTP
 
@@ -80,11 +80,10 @@ namespace bottlenose_camera_driver {
     uint32_t get_num_sensors();             ///< returns the number of sensors: 1=mono and 2=stereo    
     bool set_register(std::string, std::variant<int64_t, double, bool>); ///< set a register value on the camera
     bool m_calibrated;
-    bool m_ntp_enabled;
-    
+
     std::atomic<bool> done;               ///< Flag for management thread to terminate.
     std::thread m_thread;                 ///< Management thread handle.
-    bool m_terminate;                     ///< Flag to terminate management thread.
+    std::atomic<bool> m_terminate;        ///< Flag to terminate management thread.
     PvDeviceGEV *m_device;                ///< GEV device handle.
     PvStreamGEV *m_stream;                ///< GEV stream handle.
 

--- a/include/bottlenose_chunk_parser.hpp
+++ b/include/bottlenose_chunk_parser.hpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *  Copyright 2023 Labforge Inc.                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this project except in compliance with the License.        *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *     http://www.apache.org/licenses/LICENSE-2.0                             *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ ******************************************************************************
+
+@file bottlenose_chunk_parser.hpp Parse chunk data.
+@author G. M. Tchamgoue <martin@labforge.ca>, Thomas Reidemeister <thomas@labforge.ca>
+*/
+#ifndef __BOTTLENOSE_CHUNK_PARSER_HPP__
+#define __BOTTLENOSE_CHUNK_PARSER_HPP__
+
+#include <PvBuffer.h>
+#include <glog/logging.h>
+#include <vector>
+
+/**
+ * @brief ChunkIDs for possible buffers appended to the GEV buffer.
+ */
+typedef enum {
+  CHUNK_ID_FEATURES = 0x4001,    ///< Keypoints
+  CHUNK_ID_DESCRIPTORS = 0x4002, ///< Descriptors
+  CHUNK_ID_DNNBBOXES = 0x4003,   ///< Bounding boxes for detected targets
+  CHUNK_ID_EMBEDDINGS = 0x4004,  ///< Embeddings
+  CHUNK_ID_INFO = 0x4005,        ///< Meta information
+} chunk_type_t;
+
+/**
+ * @brief Meta information chunk data to decode timestamps.
+ */
+typedef struct __attribute__((packed, aligned(4))) {
+  uint64_t real_time;
+  uint32_t count;
+} info_t;
+
+/**
+ * Decode meta information from buffer, if present.
+ * @param buffer Buffer received on GEV interface
+ * @param info Meta information
+ * @return
+ */
+bool chunkDecodeMetaInformation(PvBuffer *buffer, info_t *info);
+
+std::string ms_to_date_string(uint64_t ms);
+
+
+#endif // __BOTTLENOSE_CHUNK_PARSER_HPP__

--- a/include/bottlenose_chunk_parser.hpp
+++ b/include/bottlenose_chunk_parser.hpp
@@ -21,7 +21,6 @@
 #define __BOTTLENOSE_CHUNK_PARSER_HPP__
 
 #include <PvBuffer.h>
-#include <glog/logging.h>
 #include <vector>
 
 /**

--- a/include/bottlenose_parameters.hpp
+++ b/include/bottlenose_parameters.hpp
@@ -77,6 +77,9 @@ const parameter_t bottlenose_parameters[] = {
   {"camera_calibration_file", rclcpp::ParameterValue("")},
   {"left_camera_calibration_file", rclcpp::ParameterValue("")},
   {"right_camera_calibration_file", rclcpp::ParameterValue("")},
+
+  /* NTP support */
+  {"ntpEnable", rclcpp::ParameterValue(false)}
 };
 
 #endif // __BOTTLENOSE_PARAMETERS_HPP__

--- a/src/bottlenose_camera_driver.cpp
+++ b/src/bottlenose_camera_driver.cpp
@@ -390,6 +390,7 @@ bool CameraDriver::set_stereo() {
 
 bool CameraDriver::set_auto_exposure() {
   bool enable_aexp = get_parameter("autoExposureEnable").as_bool();
+  RCLCPP_INFO_STREAM(get_logger(), "Auto exposure set to " << enable_aexp);
   // Apply parameter to GEV
   PvGenBoolean *gev_aexp = dynamic_cast<PvGenBoolean *>( m_device->GetParameters()->Get("autoExposureEnable"));
   if(gev_aexp == nullptr) {
@@ -407,7 +408,6 @@ bool CameraDriver::set_auto_exposure() {
       RCLCPP_ERROR(get_logger(), "Unable to register luminance target");
       return false;
     }
-
     res = gev_aexp_target->SetValue(get_parameter("autoExposureLuminanceTarget").as_int());
     if(!res.IsOK()) {
       RCLCPP_ERROR_STREAM(get_logger(), "Could not configure luminance target, cause: " << res.GetDescription().GetAscii());
@@ -419,7 +419,7 @@ bool CameraDriver::set_auto_exposure() {
       RCLCPP_ERROR(get_logger(), "Unable to register autoExposureFactor");
       return false;
     }
-    res = gev_aexp_target->SetValue(get_parameter("autoExposureFactor").as_double());
+    res = gev_aexp_gain->SetValue(get_parameter("autoExposureFactor").as_double());
     if(!res.IsOK()) {
       RCLCPP_ERROR_STREAM(get_logger(), "Could not set autoExposureFactor, cause: " << res.GetDescription().GetAscii());
       return false;
@@ -430,7 +430,7 @@ bool CameraDriver::set_auto_exposure() {
       RCLCPP_ERROR(get_logger(), "Unable to register autoGainFactor");
       return false;
     }
-    res = gev_aec_gain->SetValue(get_parameter("autoExposureFactor").as_double());
+    res = gev_aec_gain->SetValue(get_parameter("autoGainFactor").as_double());
     if(!res.IsOK()) {
       RCLCPP_ERROR_STREAM(get_logger(), "Could not set autoGainFactor, cause: " << res.GetDescription().GetAscii());
       return false;

--- a/src/bottlenose_camera_driver_node.cpp
+++ b/src/bottlenose_camera_driver_node.cpp
@@ -26,7 +26,7 @@ int main(int argc, char * argv[])
     // Force flush of the stdout buffer.
     // This ensures a correct sync of all prints
     // even when executed simultaneously within a launch file.
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
     
     rclcpp::init(argc, argv);
     rclcpp::executors::SingleThreadedExecutor exec;

--- a/src/bottlenose_chunk_parser.cpp
+++ b/src/bottlenose_chunk_parser.cpp
@@ -17,6 +17,7 @@
 @file bottlenose_chunk_parser.cpp Parse chunk data.
 @author G. M. Tchamgoue <martin@labforge.ca>, Thomas Reidemeister <thomas@labforge.ca>
 */
+#include <iomanip>
 #include "bottlenose_chunk_parser.hpp"
 #include "rclcpp/node.hpp"
 

--- a/src/bottlenose_chunk_parser.cpp
+++ b/src/bottlenose_chunk_parser.cpp
@@ -1,0 +1,167 @@
+/******************************************************************************
+ *  Copyright 2023 Labforge Inc.                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this project except in compliance with the License.        *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *     http://www.apache.org/licenses/LICENSE-2.0                             *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ ******************************************************************************
+
+@file bottlenose_chunk_parser.cpp Parse chunk data.
+@author G. M. Tchamgoue <martin@labforge.ca>, Thomas Reidemeister <thomas@labforge.ca>
+*/
+#include "bottlenose_chunk_parser.hpp"
+#include "rclcpp/node.hpp"
+
+/**
+ * Check if a defined chunk ID is present.
+ * @param buffer
+ * @param chunkID
+ * @return
+ */
+static bool hasChunkData(PvBuffer *buffer, uint32_t chunkID) {
+  if ((buffer == nullptr) || (!buffer->HasChunks())) {
+    return false;
+  }
+
+  for (size_t i = 0; i < buffer->GetChunkCount(); ++i) {
+    uint32_t id;
+    PvResult res = buffer->GetChunkIDByIndex(i, id);
+    if ((id == chunkID) && res.IsOK()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Decode uint with variable length from bytes with configurable order.
+ * @param bytes Input bytes
+ * @param len Number of bytes to decode
+ * @param little Little endian, or big endian
+ * @return Decoded uint
+ */
+static uint32_t uintFromBytes(const uint8_t *bytes, uint32_t len, bool little=true){
+  uint32_t intv = 0;
+  if((bytes == nullptr) || (len == 0) || (len > 4)){
+    return intv;
+  }
+  if(little){
+    for(int32_t i = len-1; i >= 0; i--){
+      intv = (intv << 8) | bytes[i];
+    }
+  } else{
+    for(uint32_t i = 0; i < len; ++i){
+      intv = (intv << 8) | bytes[i];
+    }
+  }
+  return intv;
+}
+
+/**
+ * Get the pointer to the chunk data by ID.
+ * @param chunkID
+ * @param rawdata
+ * @param dataSize
+ * @return
+ */
+static uint8_t *getChunkDataByID(uint32_t chunkID, const uint8_t *rawdata, uint32_t dataSize){
+  uint8_t *chunk_data = nullptr;
+  if((rawdata == nullptr) || (dataSize == 0)) {
+    return chunk_data;
+  }
+
+  int32_t pos = dataSize - 4;
+  while( pos >= 0) {
+    uint32_t chunk_len = uintFromBytes(&rawdata[pos], 4, false);
+    if((chunk_len > 0) && ((pos - 4 - chunk_len) > 0)){
+      pos -= 4;
+      uint32_t chunk_id = uintFromBytes(&rawdata[pos], 4, false);
+      pos -= chunk_len;
+      if( chunk_id == chunkID){
+        chunk_data = (uint8_t*)&rawdata[pos];
+        break;
+      }
+    }
+    pos -= 4;
+  }
+
+  return chunk_data;
+}
+
+static uint8_t *getChunkRawData(PvBuffer *buffer, chunk_type_t chunkID){
+  uint8_t *rawdata = nullptr;
+  if(buffer == nullptr){
+    return rawdata;
+  }
+
+  PvPayloadType payload = buffer->GetPayloadType();
+  if(payload == PvPayloadTypeImage){
+    if(hasChunkData(buffer, chunkID)){
+      rawdata = (uint8_t*)buffer->GetChunkRawDataByID(chunkID);
+    }
+  } else if (payload == PvPayloadTypeMultiPart){
+    if(buffer->GetMultiPartContainer()->GetPartCount() == 3){
+      IPvChunkData *chkbuffer = buffer->GetMultiPartContainer()->GetPart(2)->GetChunkData();
+      if((chkbuffer != nullptr) && (chkbuffer->HasChunks())){
+        uint8_t *dataptr = buffer->GetMultiPartContainer()->GetPart(2)->GetDataPointer();
+        uint32_t dataSize = chkbuffer->GetChunkDataSize();
+        rawdata = getChunkDataByID(chunkID, dataptr, dataSize);
+      }
+    }
+  }
+  return rawdata;
+}
+
+static bool parseMetaInformation(uint8_t *data, info_t *info, uint32_t *offset){
+  if(data == nullptr)
+    return false;
+  if(info == nullptr)
+    return false;
+  if(offset == nullptr)
+    return false;
+
+  memcpy(info, data, sizeof(info_t));
+  *offset += sizeof(info_t);
+
+  return true;
+}
+
+bool chunkDecodeMetaInformation(PvBuffer *buffer, info_t *info) {
+  uint8_t *data = getChunkRawData(buffer, CHUNK_ID_INFO);
+  if(data == nullptr) {
+    return false;
+  }
+  if(info == nullptr) {
+    return false;
+  }
+
+  uint32_t offset = 0;
+  return parseMetaInformation(data, info, &offset);
+}
+
+std::string ms_to_date_string(uint64_t ms) {
+  // Convert milliseconds to seconds
+  std::chrono::seconds seconds(ms / 1000);
+
+  // Convert to time_t
+  std::time_t time = seconds.count();
+
+  // Convert to tm struct
+  std::tm *tm_time = std::localtime(&time); // Use std::gmtime for GMT
+
+  // Format the time into a string
+  std::stringstream ss;
+  ss << std::put_time(tm_time, "%Y-%m-%d %H:%M:%S");
+
+  return ss.str();
+}
+

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -19,6 +19,7 @@
 */
 #include <PvConfigurationReader.h>
 #include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging.h"
 #include "bottlenose_camera_driver.hpp"
 #include <gtest/gtest.h>
 #include <ament_index_cpp/get_package_share_directory.hpp>
@@ -245,6 +246,8 @@ namespace {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
+
+  rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
   rclcpp::init(0, nullptr);
   return RUN_ALL_TESTS();
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -69,7 +69,7 @@ namespace {
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
       // Create subscriber to image topic
-      auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
+      auto image_subscriber = std::make_shared<ImageSubscriber>("image_color");
       exec.add_node(image_subscriber);
       std::thread spin_thread([&exec]() {
         while(!done) {
@@ -111,7 +111,7 @@ namespace {
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
       // Create subscriber to image topic
-      auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
+      auto image_subscriber = std::make_shared<ImageSubscriber>("image_color");
       exec.add_node(image_subscriber);
       std::thread spin_thread([&exec]() {
         while(!done) {
@@ -148,7 +148,7 @@ namespace {
       // Fire up ROS driver
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
-      auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
+      auto image_subscriber = std::make_shared<ImageSubscriber>("image_color");
       exec.add_node(image_subscriber);
       std::thread spin_thread([&exec]() {
         while(!done) {
@@ -185,7 +185,7 @@ namespace {
       // Fire up ROS driver
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
-      auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
+      auto image_subscriber = std::make_shared<ImageSubscriber>("image_color");
       exec.add_node(image_subscriber);
       std::thread spin_thread([&exec]() {
         while(!done) {
@@ -222,7 +222,7 @@ namespace {
       // Fire up ROS driver
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
-      auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
+      auto image_subscriber = std::make_shared<ImageSubscriber>("image_color");
       exec.add_node(image_subscriber);
       std::thread spin_thread([&exec]() {
         while(!done) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -28,7 +28,7 @@ namespace {
   using namespace std;
   using namespace std::literals::chrono_literals;
 
-  const int expected_image_delay = 10;
+  const int expected_image_delay = 5;
 
   /**
    * @brief Class to subscribe to the first message received in a topic.

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -27,6 +27,8 @@ namespace {
   using namespace std;
   using namespace std::literals::chrono_literals;
 
+  const int expected_image_delay = 10;
+
   /**
    * @brief Class to subscribe to the first message received in a topic.
    */
@@ -67,12 +69,13 @@ namespace {
       exec.add_node(bottlenose_camera_driver);
       // Create subscriber to image topic
       auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
+      exec.add_node(image_subscriber);
       std::thread spin_thread([&exec]() {
         while(!done) {
           exec.spin_once(100ms);
         }
       });
-      sleep(3);
+      sleep(expected_image_delay);
       done = true;
       spin_thread.join();
       sleep(1);
@@ -108,12 +111,13 @@ namespace {
       exec.add_node(bottlenose_camera_driver);
       // Create subscriber to image topic
       auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
-      std::thread spin_thread([&exec, &bottlenose_camera_driver]() {
+      exec.add_node(image_subscriber);
+      std::thread spin_thread([&exec]() {
         while(!done) {
           exec.spin_once(100ms);
         }
       });
-      sleep(3);
+      sleep(expected_image_delay);
       done = true;
       spin_thread.join();
       sleep(1);
@@ -144,12 +148,13 @@ namespace {
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
       auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
-      std::thread spin_thread([&exec, &bottlenose_camera_driver]() {
+      exec.add_node(image_subscriber);
+      std::thread spin_thread([&exec]() {
         while(!done) {
           exec.spin_once(100ms);
         }
       });
-      sleep(3);
+      sleep(expected_image_delay);
       done = true;
       spin_thread.join();
       sleep(1);
@@ -180,12 +185,13 @@ namespace {
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
       auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
-      std::thread spin_thread([&exec, &bottlenose_camera_driver]() {
+      exec.add_node(image_subscriber);
+      std::thread spin_thread([&exec]() {
         while(!done) {
           exec.spin_once(100ms);
         }
       });
-      sleep(3);
+      sleep(expected_image_delay);
       done = true;
       spin_thread.join();
       sleep(1);
@@ -216,12 +222,13 @@ namespace {
       rclcpp::executors::SingleThreadedExecutor exec;
       exec.add_node(bottlenose_camera_driver);
       auto image_subscriber = std::make_shared<ImageSubscriber>("image_raw");
+      exec.add_node(image_subscriber);
       std::thread spin_thread([&exec]() {
         while(!done) {
           exec.spin_once(100ms);
         }
       });
-      sleep(6);
+      sleep(expected_image_delay);
       done = true;
       spin_thread.join();
       sleep(1);


### PR DESCRIPTION
 * Enable autoexposure properly in ROS2 (SE-2565)
 * Enable ntp support in ROS2 (SE-2568)
 * Decode real-time stamps from chunk data instead of Pleora-assigned timestamp