### PR TITLE
Bypass any existing proxy configuration

### DIFF
--- a/src/bottlenose_camera_driver.cpp
+++ b/src/bottlenose_camera_driver.cpp
@@ -1602,6 +1602,8 @@ bool CameraDriver::ftp_upload(const std::string &ftp_url, const std::string &fil
     curl_easy_setopt(curl, CURLOPT_READDATA, hd_src);
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, fsize);
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, curlReadCallback);
+    // Disable the use of a proxy. Important for ensuring the connection is direct to the IP.
+    curl_easy_setopt(curl, CURLOPT_PROXY, "");
     curl_easy_setopt(curl, CURLOPT_FTPPORT, "-"); // Use "-" to enable active mode, PASV not supported by camera
 
     // Perform the upload


### PR DESCRIPTION
 * file transfers to bottlenose can get blocked as curl falls back to the proxy configuration
 * Since the transfer is supposed to be IP-based the notion of a proxy is useless
 * Explicitly bypass any system proxys